### PR TITLE
Removed recursive method invocation

### DIFF
--- a/tuprolog/core/_ktadapt.py
+++ b/tuprolog/core/_ktadapt.py
@@ -64,7 +64,7 @@ class _KtTerm:
 
     @property
     def is_integer(self):
-        return self.is_integer()
+        return self.isInteger()
 
     @property
     def is_real(self):


### PR DESCRIPTION
Removed recursive method invocation in `tuprolog.core._ktadapt.py` for property `is_integer`.